### PR TITLE
Task: Add Support for Client Ping/Pong Messages #42

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/remotehq/websocketproxy
+
+go 1.14
+
+require github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -57,9 +57,6 @@ type WebsocketProxy struct {
 type ProxyConfig struct {
 	// Indicates whether a ping message should be handled from the client with a pong response
 	SupportClientPingPong bool
-
-	// Indicates whether a ping message should be handled from the backend with a pong response
-	SupportBackendPingPong bool
 }
 
 // ProxyHandler returns a new http.Handler interface that reverse proxies the
@@ -225,7 +222,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	go replicateWebsocketConn(connPub, connBackend, errClient, w.config.SupportBackendPingPong)
+	go replicateWebsocketConn(connPub, connBackend, errClient, false)
 	go replicateWebsocketConn(connBackend, connPub, errBackend, w.config.SupportClientPingPong)
 
 	var message string


### PR DESCRIPTION
This PR adds the ability for the proxy to support ping/pong messages between the client and the proxy. Additionally, support for go modules has been added.